### PR TITLE
Fixed NTP sync while using DHCP.

### DIFF
--- a/files/image_config/ntp/ntp.conf.j2
+++ b/files/image_config/ntp/ntp.conf.j2
@@ -29,9 +29,13 @@ server {{ ntp_server }} iburst
 
 #only listen on localhost and eth0 ips (default is to listen on all ip addresses)
 interface ignore wildcard
+{% if MGMT_INTERFACE %}
 {% for (mgmt_intf, mgmt_prefix) in MGMT_INTERFACE %}
 interface listen {{ mgmt_prefix | ip }}
 {% endfor %}
+{% else %}
+interface listen eth0
+{% endif %}
 interface listen 127.0.0.1
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for


### PR DESCRIPTION
**- What I did**

Fixed NTP sync by adding interface to listen when using DHCP.

**- How I did it**

interface listen eth0

**- How to verify it**
```
admin@sonic:~$ show ntp
Command: ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 107.191.112.226 .INIT.          16 -    -  512    0    0.000    0.000   0.000
 192.146.137.13  .INIT.          16 -    -  512    0    0.000    0.000   0.000
 ntp-ext.cosng.n .INIT.          16 -    -  512    0    0.000    0.000   0.000
 ntp3.ds.network .INIT.          16 -    -  512    0    0.000    0.000   0.000
```
```
admin@sonic:~$ show ntp
Command: ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
-mail.fangfufu.c 193.190.230.66   2 u   35   64    1  144.849   -3.925   3.381
*tirpitz.netzkon 213.172.96.14    2 u   96   64    1  170.649   -8.120   0.798
+services.quadra 45.79.111.114    3 u   57   64    7   15.488   -8.208   4.318
+panel1.web2.clu 85.214.59.199    3 u   58   64    3  156.818   -8.732   1.505
```